### PR TITLE
fix logistic page ancor navigation bug

### DIFF
--- a/js/hci.js
+++ b/js/hci.js
@@ -1,5 +1,13 @@
 $(document).ready(function() {
     initializeSideNav();
+    var offset = 60;
+
+    $('#sidenav-content li a').click(function(event) {
+        event.preventDefault();
+        $($(this).attr('href'))[0].scrollIntoView();
+        scrollBy(0, -offset);
+    });
+
 });
 
 function initializeSideNav() {


### PR DESCRIPTION
On the logistic page, if user click the left side scrollspy link, the top content would be covered by top navbar, add a click event to move to appropriate position. 
